### PR TITLE
Fix deletemember bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -24,6 +24,9 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
 
+    public static final String MESSAGE_PERSON_IN_EXISITING_GROUP =
+        "The person specified is still in one or more groups!";
+
     private final Index targetIndex;
 
     public DeleteCommand(Index targetIndex) {
@@ -40,6 +43,11 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        if (personToDelete.getPersonGroups().size() > 0) {
+            throw new CommandException(MESSAGE_PERSON_IN_EXISITING_GROUP);
+        }
+        
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -47,7 +47,7 @@ public class DeleteCommand extends Command {
         if (personToDelete.getPersonGroups().size() > 0) {
             throw new CommandException(MESSAGE_PERSON_IN_EXISITING_GROUP);
         }
-        
+
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupMemberCommand.java
@@ -68,7 +68,7 @@ public class DeleteGroupMemberCommand extends Command {
         }
 
         if (!groupToDeletePerson.contains(personToGroup)) {
-            throw new CommandException(String.format(MESSAGE_PERSON_NOT_IN_GROUP, this.name));
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_IN_GROUP, this.name, this.personGroup));
         }
         //change field
         ArrayList<PersonGroup> personGroupArrayList = personToGroup.getPersonGroups();

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupMemberCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupMemberCommand.java
@@ -72,6 +72,12 @@ public class DeleteGroupMemberCommand extends Command {
         }
         //change field
         ArrayList<PersonGroup> personGroupArrayList = personToGroup.getPersonGroups();
+        ArrayList<PersonGroup> personGroupArrayListCopy = new ArrayList<>(personGroupArrayList);
+        Person originalPersonBeforeEdit = new Person(
+            personToGroup.getName(), personToGroup.getPhone(), personToGroup.getEmail(),
+            personToGroup.getAddress(), personToGroup.getTags(), personToGroup.getAssignments(),
+            personGroupArrayListCopy);
+
         personGroupArrayList.remove(this.personGroup);
 
         Person editedPerson = new Person(
@@ -79,10 +85,11 @@ public class DeleteGroupMemberCommand extends Command {
                 personToGroup.getAddress(), personToGroup.getTags(), personToGroup.getAssignments(),
                 personGroupArrayList);
 
+
         //deletes person from the group
         Set<Person> groupMembers = new HashSet<>();
         groupMembers.addAll(groupToDeletePerson.getMembers());
-        groupMembers.remove(editedPerson);
+        groupMembers.remove(originalPersonBeforeEdit);
         Group editedGroup = new Group(groupToDeletePerson.getName(), groupMembers);
 
 


### PR DESCRIPTION
The bug arises when the following commands are executed on TABS, namely when deletemember on the same person is executed twice. This is because the variables personGroupArrayList and editedPerson are changed, while the old copies of the variables are not stored. This results in Set#remove(editedPerson) to not work as intended. 

The following commands can be used to test the bug fix: 
- addgroup g/CS2103T 
- addgroup g/CS 
- addmember g/CS2103T n/Alex Yeoh 
- addmember g/CS n/Alex Yeoh 
- deletemember g/CS2103T n/Alex Yeoh 
- deletemember g/CS n/Alex Yeoh 


Other minor bug fixes:
- Error message for displaying person not in group
- Throwing error when person still in one or more existing group