### PR TITLE
Use shift to navigate tabs (Do not merge)

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,7 +1,13 @@
 package seedu.address.ui;
 
+
+import java.util.Timer;
 import java.util.logging.Logger;
 
+import javafx.animation.Timeline;
+import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
@@ -24,6 +30,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import javafx.scene.input.KeyCode;
 import javafx.scene.control.SkinBase;
 import com.sun.javafx.scene.control.behavior.TabPaneBehavior;
+import javafx.animation.Timeline;
+import javafx.util.Duration;
+import javafx.animation.KeyFrame;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -105,6 +114,44 @@ public class MainWindow extends UiPart<Stage> {
 
 
     private void setAccelerator(TabPane tabPane) {
+
+
+        tabPane.getSelectionModel().selectedIndexProperty().addListener(new ChangeListener<Number>() {
+
+            @Override
+            public void changed(ObservableValue<? extends Number> ov, Number t, final Number t1) {
+                Platform.runLater(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        if (tabPane.getTabs().size() > 0) {
+                            final Tab tab = (Tab) tabPane.getTabs().get(t1.intValue());
+
+                            final Timeline animation = new Timeline(
+                                    new KeyFrame(Duration.millis(25),
+                                    new EventHandler<ActionEvent>() {
+                                        @Override
+                                        public void handle(ActionEvent actionEvent) {
+                                            Platform.runLater(new Runnable() {
+
+                                                @Override
+                                                public void run() {
+                                                    tab.getContent().requestFocus();
+                                                }
+                                            });
+                                        }
+                                    }));
+                            animation.setCycleCount(1);
+                            animation.play();
+                        }
+                    }
+                });
+
+            }
+        });
+
+
+
 
         tabPane.addEventFilter(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
             @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -3,11 +3,14 @@ package seedu.address.ui;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
+import javafx.scene.Scene;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.control.skin.TabPaneSkin;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
@@ -18,6 +21,9 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import javafx.scene.input.KeyCode;
+import javafx.scene.control.SkinBase;
+import com.sun.javafx.scene.control.behavior.TabPaneBehavior;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -82,6 +88,10 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
+
+
+
     }
 
     public Stage getPrimaryStage() {
@@ -90,7 +100,47 @@ public class MainWindow extends UiPart<Stage> {
 
     private void setAccelerators() {
         setAccelerator(helpMenuItem, KeyCombination.valueOf("F1"));
+        setAccelerator(dataPanelsTabPanes);
     }
+
+
+    private void setAccelerator(TabPane tabPane) {
+
+        tabPane.addEventFilter(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
+            @Override
+            public void handle(KeyEvent t) {
+                if (t.getCode().equals(KeyCode.TAB) ) {
+                    int size = tabPane.getTabs().size();
+
+                    if (size > 0) {
+                        // TabPaneSkin skin = (TabPaneSkin) tabPane.getSkin();
+                        TabPaneBehavior tabPaneBehavior = new TabPaneBehavior(tabPane);
+
+                        int selectedIndex = tabPane.getSelectionModel().getSelectedIndex();
+
+                        if (!t.isShiftDown()) {
+                            if (selectedIndex < size -1) {
+                                tabPaneBehavior.selectNextTab();
+                            } else {
+                                tabPaneBehavior.selectTab(tabPane.getTabs().get(0));
+                            }
+                        } else {
+                            if (selectedIndex > 0) {
+                                tabPaneBehavior.selectPreviousTab();
+                            } else {
+                                tabPaneBehavior.selectTab(tabPane.getTabs().get(size - 1));
+                            }
+                        }
+
+                        t.consume();
+                    }
+
+                }
+            }
+        });
+    }
+
+
 
     /**
      * Sets the accelerator of a MenuItem.
@@ -120,6 +170,9 @@ public class MainWindow extends UiPart<Stage> {
                 event.consume();
             }
         });
+
+
+
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,7 +1,5 @@
 package seedu.address.ui;
 
-
-import java.util.Timer;
 import java.util.logging.Logger;
 
 import javafx.animation.Timeline;
@@ -11,12 +9,10 @@ import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
-import javafx.scene.Scene;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
-import javafx.scene.control.skin.TabPaneSkin;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
@@ -28,9 +24,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import javafx.scene.input.KeyCode;
-import javafx.scene.control.SkinBase;
 import com.sun.javafx.scene.control.behavior.TabPaneBehavior;
-import javafx.animation.Timeline;
 import javafx.util.Duration;
 import javafx.animation.KeyFrame;
 
@@ -128,7 +122,7 @@ public class MainWindow extends UiPart<Stage> {
                             final Tab tab = (Tab) tabPane.getTabs().get(t1.intValue());
 
                             final Timeline animation = new Timeline(
-                                    new KeyFrame(Duration.millis(25),
+                                    new KeyFrame(Duration.millis(1),
                                     new EventHandler<ActionEvent>() {
                                         @Override
                                         public void handle(ActionEvent actionEvent) {
@@ -151,12 +145,10 @@ public class MainWindow extends UiPart<Stage> {
         });
 
 
-
-
         tabPane.addEventFilter(KeyEvent.KEY_PRESSED, new EventHandler<KeyEvent>() {
             @Override
             public void handle(KeyEvent t) {
-                if (t.getCode().equals(KeyCode.TAB) ) {
+                if (t.getCode().equals(KeyCode.SHIFT) ) {
                     int size = tabPane.getTabs().size();
 
                     if (size > 0) {

--- a/src/main/java/seedu/address/ui/TabPaneManager.java
+++ b/src/main/java/seedu/address/ui/TabPaneManager.java
@@ -42,4 +42,9 @@ public class TabPaneManager {
         SingleSelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
         selectionModel.select(assignmentTabPage);
     }
+
+    
+
+
+
 }


### PR DESCRIPTION
Shift to navigate around tabs.

Problems:
- Have to make sure that the TabPane is in focus first

Proposed solution (NOT YET IMPLEMENTED):
- Implementing a one click (SHIFT) navigation to replace the current navigation which requires TABS and arrow keys