### PR TITLE
Fix bug for deletegroup command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -5,12 +5,14 @@ import static seedu.address.logic.commands.AssignTaskCommand.MESSAGE_INVALID_GRO
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonGroup;
 
@@ -66,9 +68,25 @@ public class DeleteGroupCommand extends Command {
                     currentPerson.getName(), currentPerson.getPhone(), currentPerson.getEmail(),
                     currentPerson.getAddress(), currentPerson.getTags(), currentPerson.getAssignments(),
                     currentPerson.getPersonGroups());
+
             editedPerson.getPersonGroups().remove(new PersonGroup(groupToCheck.getName().toString()));
             editedPerson.getAssignments().remove((groupToCheck.getName().toString()));
+
             model.setPerson(currentPerson, editedPerson);
+
+            for (PersonGroup group : editedPerson.getPersonGroups()) {
+                ObservableList<Group> currGroupList = model.getGroupWithName(new GroupName(group.getGroupName()));
+                Group currGroup = currGroupList.get(0);
+
+                Set<Person> editedPersonList = new HashSet<Person>();
+                editedPersonList.addAll(currGroup.getMembers());
+                editedPersonList.remove(currentPerson);
+                editedPersonList.add(editedPerson);
+
+                Group editedGroup = new Group(currGroup.getName(), editedPersonList);
+
+                model.setGroup(currGroup, editedGroup);
+            }
         }
 
         model.deleteGroup(groupToCheck);

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.commands.AssignTaskCommand.MESSAGE_INVALID_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -54,11 +53,7 @@ public class DeleteGroupCommand extends Command {
 
         //the group specified cannot be found
         Group groupToCheck;
-        try {
-            groupToCheck = groupList.get(0);
-        } catch (IndexOutOfBoundsException e) {
-            throw new CommandException(MESSAGE_INVALID_GROUP);
-        }
+        groupToCheck = groupList.get(0);
 
         Set<Person> groupMembers = groupToCheck.getMembers();
 
@@ -75,23 +70,26 @@ public class DeleteGroupCommand extends Command {
             model.setPerson(currentPerson, editedPerson);
 
             for (PersonGroup group : editedPerson.getPersonGroups()) {
-                ObservableList<Group> currGroupList = model.getGroupWithName(new GroupName(group.getGroupName()));
-                Group currGroup = currGroupList.get(0);
-
-                Set<Person> editedPersonList = new HashSet<Person>();
-                editedPersonList.addAll(currGroup.getMembers());
-                editedPersonList.remove(currentPerson);
-                editedPersonList.add(editedPerson);
-
-                Group editedGroup = new Group(currGroup.getName(), editedPersonList);
-
-                model.setGroup(currGroup, editedGroup);
+                this.updateExistingGroups(model, currentPerson, editedPerson, group);
             }
         }
 
         model.deleteGroup(groupToCheck);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, groupToCheck));
+    }
+
+    private void updateExistingGroups(Model model, Person currentPerson, Person editedPerson, PersonGroup group) {
+        ObservableList<Group> currGroupList = model.getGroupWithName(new GroupName(group.getGroupName()));
+        Group currGroup = currGroupList.get(0);
+
+        Set<Person> editedPersonList = new HashSet<Person>(currGroup.getMembers());
+        editedPersonList.remove(currentPerson);
+        editedPersonList.add(editedPerson);
+
+        Group editedGroup = new Group(currGroup.getName(), editedPersonList);
+
+        model.setGroup(currGroup, editedGroup);
     }
 
     @Override

--- a/src/test/data/JsonSerializableAddressBookTest/typicalGroupsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalGroupsAddressBook.json
@@ -20,7 +20,8 @@
     "email" : "heinz@example.com",
     "address" : "wall street",
     "tagged" : [ ],
-    "assignments": { }
+    "assignments": { },
+    "personGroup" : [ "Team Project", "Team Coursework" ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
@@ -70,5 +71,8 @@
   }, {
     "members" : ["Elle Meyer", "Fiona Kunz", "George Best"],
     "groupName" : "Oral Presentation"
+  }, {
+    "members" : ["Carl Kurz"],
+    "groupName" : "Team Coursework"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -20,7 +20,8 @@
     "email" : "heinz@example.com",
     "address" : "wall street",
     "tagged" : [ ],
-    "assignments": { }
+    "assignments": { },
+    "personGroup" : [ "Team Project", "Team Coursework" ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",

--- a/src/test/java/seedu/address/logic/commands/AssignTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignTaskCommandTest.java
@@ -188,8 +188,6 @@ public class AssignTaskCommandTest {
                 new Assignment(assignmentName)
         );
 
-        System.out.println(model.getFilteredGroupList());
-
         model.setPerson(personToAssignTask, editedPerson);
 
         assertCommandFailure(assignTaskCommand, model, AssignTaskCommand.MESSAGE_INVALID_PERSON_NOT_IN_GROUP);

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -9,6 +9,10 @@ import static seedu.address.model.group.testutil.TypicalGroups.TEAM_PROJECT;
 import static seedu.address.model.group.testutil.TypicalGroups.getTypicalAddressBookWithGroups;
 import static seedu.address.model.person.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
@@ -16,6 +20,9 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonGroup;
 import seedu.address.model.person.testutil.GroupBuilder;
 
 public class DeleteGroupCommandTest {
@@ -30,6 +37,34 @@ public class DeleteGroupCommandTest {
         String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_SUCCESS, groupToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        Set<Person> currMembers = new HashSet<Person>(expectedModel
+                .getGroupWithName(groupToDelete.getName()).get(0).getMembers());
+
+        PersonGroup personGroupToRemove = new PersonGroup(groupToDelete.getName().groupName);
+
+        for (Person p : currMembers) {
+            ArrayList<PersonGroup> editedPersonGroup = new ArrayList<>(p.getPersonGroups());
+
+            editedPersonGroup.remove(personGroupToRemove);
+            Person editedPerson = new Person(p.getName(), p.getPhone(), p.getEmail(), p.getAddress(),
+                    p.getTags(), p.getAssignments(), editedPersonGroup);
+
+            for (PersonGroup pg : editedPersonGroup) {
+                Group currGroup = expectedModel.getGroupWithName(new GroupName(pg.getGroupName())).get(0);
+                Set<Person> editedPersonList = new HashSet<Person>(currGroup.getMembers());
+
+                editedPersonList.remove(p);
+                editedPersonList.add(editedPerson);
+
+                Group expectedGroup = new Group(currGroup.getName(), editedPersonList);
+
+                expectedModel.setGroup(currGroup, expectedGroup);
+            }
+
+            expectedModel.setPerson(p, editedPerson);
+        }
+
         expectedModel.deleteGroup(groupToDelete);
 
         assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/model/group/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/model/group/testutil/TypicalGroups.java
@@ -37,6 +37,9 @@ public class TypicalGroups {
     public static final Group ORAL_PRESENTATION =
             new GroupBuilder().withName("Oral Presentation").withMembers(ELLE, FIONA, GEORGE).build();
 
+    public static final Group TEAM_COURSEWORK =
+            new GroupBuilder().withName("Team Coursework").withMembers(CARL).build();
+
     /**
      * Returns an {@code AddressBook} with all the typical persons and sample groups.
      * @return
@@ -53,6 +56,6 @@ public class TypicalGroups {
     }
 
     public static List<Group> getTypicalGroups() {
-        return new ArrayList<>(Arrays.asList(TEAM_PROJECT, INDIVIDUAL_PROJECT, ORAL_PRESENTATION));
+        return new ArrayList<>(Arrays.asList(TEAM_PROJECT, INDIVIDUAL_PROJECT, ORAL_PRESENTATION, TEAM_COURSEWORK));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -70,8 +70,7 @@ public class PersonTest {
                 + "Address: 123, Jurong West Ave 6, #08-111; "
                 + "Tags: [friends]; "
                 + "Assignment: Group 1 [Midterms (LOW)]";
-        System.out.println(str);
-        System.out.println(aliliCopy.toString());
+
         assertTrue(aliliCopy.toString().equals(str));
     }
 

--- a/src/test/java/seedu/address/model/person/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/model/person/testutil/TypicalPersons.java
@@ -33,7 +33,9 @@ public class TypicalPersons {
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com")
+            .withAddress("wall street")
+            .withGroups(new String[]{"Team Project", "Team Coursework"}).build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -33,6 +33,10 @@ public class JsonSerializableAddressBookTest {
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
         AddressBook typicalPersonsAddressBook = TypicalPersons.getTypicalAddressBook();
+
+        System.out.println(addressBookFromFile.getPersonList());
+        System.out.println(typicalPersonsAddressBook.getPersonList());
+
         assertEquals(addressBookFromFile, typicalPersonsAddressBook);
     }
 
@@ -58,6 +62,9 @@ public class JsonSerializableAddressBookTest {
         AddressBook addressBookFromFile = dataFromFile.toModelType();
 
         AddressBook typicalPersonsAddressBookWithGroups = TypicalGroups.getTypicalAddressBookWithGroups();
+
+        System.out.println(addressBookFromFile.getPersonList());
+        System.out.println(typicalPersonsAddressBookWithGroups.getPersonList());
 
         assertEquals(addressBookFromFile, typicalPersonsAddressBookWithGroups);
     }


### PR DESCRIPTION
Problem : When deleting a `Group`, the `Group` is removed from the `PersonGroup` in each member, and this causes the `Person` is not identical to the other `Person` in other groups.

Solution : Update each `Person` in their groups to prevent `PersonNotFoundException` exception.